### PR TITLE
fix: Skip pure variable assignments in shellsplit

### DIFF
--- a/internal/shellsplit/shellsplit.go
+++ b/internal/shellsplit/shellsplit.go
@@ -43,8 +43,23 @@ func Split(cmd string) []string {
 		// Collect leaf commands (simple commands, declarations, test expressions).
 		// Skip compound nodes (BinaryCmd, IfClause, etc.) — Walk descends
 		// into them to find the leaf commands inside.
-		switch stmt.Cmd.(type) {
-		case *syntax.CallExpr, *syntax.DeclClause, *syntax.TestClause:
+		switch cmd := stmt.Cmd.(type) {
+		case *syntax.CallExpr:
+			// Skip pure variable assignments (e.g. "FOO=$(cmd)").
+			// The inner command substitution is already extracted by
+			// the walk, so emitting the assignment wrapper would create
+			// a phantom sub-command that matches no rules and causes
+			// passthrough to override real decisions in compound eval.
+			if len(cmd.Args) == 0 && len(cmd.Assigns) > 0 {
+				break
+			}
+			var buf bytes.Buffer
+			printer.Print(&buf, stmt)
+			s := strings.TrimSpace(buf.String())
+			if s != "" {
+				commands = append(commands, s)
+			}
+		case *syntax.DeclClause, *syntax.TestClause:
 			var buf bytes.Buffer
 			printer.Print(&buf, stmt)
 			s := strings.TrimSpace(buf.String())

--- a/internal/shellsplit/shellsplit_test.go
+++ b/internal/shellsplit/shellsplit_test.go
@@ -141,6 +141,63 @@ func TestSplit(t *testing.T) {
 			input: "if [[ -f foo ]]; then echo yes; fi",
 			want:  []string{"[[ -f foo ]]", "echo yes"},
 		},
+		// Variable assignments — should not emit the assignment wrapper
+		{
+			name:  "variable assignment with command substitution",
+			input: "VAR=$(git status) && echo $VAR",
+			want:  []string{"git status", "echo $VAR"},
+		},
+		{
+			name:  "pure variable assignment without command",
+			input: "FOO=bar",
+			want:  []string{"FOO=bar"}, // fallback: single element returned as-is
+		},
+		{
+			name:  "variable assignment before command preserved",
+			input: "FOO=bar cmd arg",
+			want:  []string{"FOO=bar cmd arg"},
+		},
+		{
+			name:  "export with command substitution",
+			input: "export VAR=$(whoami) && echo done",
+			want:  []string{"export VAR=$(whoami)", "whoami", "echo done"},
+		},
+		{
+			name:  "multiple assignments with command substitution",
+			input: "A=$(cmd1) && B=$(cmd2) && echo $A $B",
+			want:  []string{"cmd1", "cmd2", "echo $A $B"},
+		},
+		// Security: dangerous commands inside assignments must still be extracted
+		{
+			name:  "dangerous command in assignment is extracted",
+			input: "DANGEROUS=$(rm -rf /) && echo done",
+			want:  []string{"rm -rf /", "echo done"},
+		},
+		{
+			name:  "multiple pure assignments no command",
+			input: "A=1 B=2",
+			want:  []string{"A=1 B=2"}, // fallback: single element returned as-is
+		},
+		{
+			name:  "single assignment with command substitution",
+			input: "A=$(dangerous_cmd)",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
+			name:  "env var prefix before command preserved",
+			input: "PATH=/tmp:$PATH cmd",
+			want:  []string{"PATH=/tmp:$PATH cmd"},
+		},
+		{
+			name:  "declare with command substitution emits both",
+			input: "declare -x FOO=$(cmd)",
+			want:  []string{"declare -x FOO=$(cmd)", "cmd"},
+		},
+		{
+			name:  "nested substitution in assignment",
+			input: "X=$(echo $(rm -rf /)) && ls",
+			want:  []string{"echo $(rm -rf /)", "rm -rf /", "ls"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Variable assignments like `VAR=$(cmd)` were emitted as standalone sub-commands by shellsplit, causing phantom passthrough results that overrode real allow/deny decisions in compound evaluation
- Now `CallExpr` nodes with `Assigns` but no `Args` are skipped — inner command substitutions are already extracted by the AST walk
- Added 11 new test cases covering variable assignments, security invariants (dangerous commands inside assignments are still extracted), env-var prefixes, `declare` clauses, and nested substitutions

## Root Cause

`GITHUB_OWNER=$(gh api user --jq '.login') && gh issue comment ...` produced 4 sub-commands. The assignment wrapper matched no rules → passthrough (priority 1) overrode the allow results (priority 0) for the actual commands. The compound result was passthrough with no audit log entry, making the hook appear silent.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all 37 shellsplit tests pass (11 new)
- [x] `go build ./cmd/claude-approve/` — builds cleanly
- [x] Security review: dangerous commands inside `$(...)` are still extracted because `syntax.Walk` descends unconditionally
- [x] Verified with exact failing command from production: now produces 3 sub-commands (no assignment wrapper)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)