### PR TITLE
feat: Add config integration tests from audit log

### DIFF
--- a/examples/hooks-config.toml
+++ b/examples/hooks-config.toml
@@ -11,7 +11,7 @@ audit_level = "matched"  # off | matched | all
 
 [[deny]]
 tool = "Bash"
-command_regex = "^rm .*-rf"
+command_regex = "^rm\\b.*(-rf|-fr)"
 reason = "Blocked rm -rf"
 
 [[deny]]
@@ -35,7 +35,7 @@ reason = "Blocked writing secrets (.env/.pem/.key)"
 
 [[allow]]
 tool = "Bash"
-command_regex = "^(bash|cargo|cat|cp|curl|diff|du|echo|env|export|file|find|grep|head|kill|killall|ls|lsof|make|mkdir|mv|nc|npm|npx|open|pgrep|pkill|pwd|pytest|sort|tail|tee|test|touch|tree|unzip|wc|which|yq)( |$)"
+command_regex = "^(cargo|cat|cp|curl|diff|du|echo|env|export|file|find|grep|head|kill|killall|ls|lsof|make|mkdir|mv|nc|npm|npx|open|pgrep|pkill|pwd|pytest|sort|tail|tee|test|touch|tree|unzip|wc|which|yq)( |$)"
 command_exclude_regex = "&&|;|`|\\$\\("
 reason = "Simple command (no chaining)"
 

--- a/internal/engine/config_integration_test.go
+++ b/internal/engine/config_integration_test.go
@@ -56,6 +56,12 @@ func TestExampleConfig(t *testing.T) {
 			wantDecision: DecisionDeny,
 		},
 		{
+			name:         "deny: rm -fr (swapped flags)",
+			toolName:     "Bash",
+			command:      "rm -fr /tmp/important",
+			wantDecision: DecisionDeny,
+		},
+		{
 			name:         "deny: chmod",
 			toolName:     "Bash",
 			command:      "chmod +x scripts/deploy.sh",
@@ -169,17 +175,19 @@ func TestExampleConfig(t *testing.T) {
 			command:      "env",
 			wantDecision: DecisionAllow,
 		},
+		// bash removed from simple-command list to prevent
+		// bash -c 'dangerous cmd' from bypassing deny rules.
 		{
-			name:         "allow: bash script",
+			name:         "passthrough: bash script",
 			toolName:     "Bash",
 			command:      "bash /tmp/script.sh",
-			wantDecision: DecisionAllow,
+			wantDecision: DecisionPassthrough,
 		},
 		{
-			name:         "allow: bash -c",
+			name:         "passthrough: bash -c (deny bypass prevention)",
 			toolName:     "Bash",
-			command:      "bash -c 'echo hello'",
-			wantDecision: DecisionAllow,
+			command:      "bash -c 'rm -rf /'",
+			wantDecision: DecisionPassthrough,
 		},
 		{
 			name:         "allow: cat file",
@@ -456,6 +464,12 @@ func TestExampleConfig(t *testing.T) {
 			toolName:     "Write",
 			filePath:     "/project/private.key",
 			wantDecision: DecisionDeny,
+		},
+		{
+			name:         "passthrough: write .env.local (deny needs $ anchor)",
+			toolName:     "Write",
+			filePath:     "/project/.env.local",
+			wantDecision: DecisionPassthrough,
 		},
 		{
 			name:         "passthrough: edit .env excluded",


### PR DESCRIPTION
## Summary
- Add `TestExampleConfig` with 69 test cases derived from real production audit logs
- Update `examples/hooks-config.toml` to match the current production config (shell builtins rule, expanded simple command list, `( |$)` for no-arg commands, `.arb`/`.xml` extensions, shorter reason strings)
- Tests cover: deny (rm -rf, chmod, sudo), allow (dev tools, simple commands, shell builtins, project scripts, compound commands), passthrough (unknown commands), file tools (Read/Edit/Write with extension and exclusion rules), ask (lock/sum files)

Fixes #4

## Test plan
- [x] `go test -v -run TestExampleConfig ./internal/engine/` — all 69 pass
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)