### PR TITLE
security: pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to commit SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- Pin `actions/setup-go` to commit SHA `40f1582b2485089dde7abd97c1529aa768e1baff` (v5.6.0)
- Add `.github/dependabot.yml` for weekly automated GitHub Actions updates

Fixes #29

## Test plan
- [x] Verification checks pass (`go vet ./... && go test ./...`)
- [x] SHAs verified via GitHub API against v4.3.1 and v5.6.0 tags