### PR TITLE
fix: improve Warnings() message for trailing | in alternation pattern

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,13 +226,13 @@ func firstUnanchoredBranch(pattern string) (string, bool) {
 }
 
 // alternationWarning formats a warning message for a regex field whose
-// alternation contains an unanchored branch. When branch is empty (caused by a
-// trailing "|"), the message explicitly names the empty branch rather than
-// printing the confusing bare `(branch: "")`.
+// alternation contains an unanchored branch. When branch is empty (from a
+// trailing "|" or a middle "||"), the message explicitly calls out the empty
+// branch rather than printing the confusing bare `(branch: "")`.
 func alternationWarning(field, reason, pattern, branch string) string {
 	if branch == "" {
 		return fmt.Sprintf(
-			"rule %q: %s %q has a trailing | that creates an empty unanchored branch; the empty branch matches any path as a substring, which may allow traversal bypass",
+			"rule %q: %s %q has an empty alternation branch without a ^ anchor; empty branches match any path as a substring, which may allow traversal bypass",
 			reason, field, pattern,
 		)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,23 @@ func firstUnanchoredBranch(pattern string) (string, bool) {
 	return "", false
 }
 
+// alternationWarning formats a warning message for a regex field whose
+// alternation contains an unanchored branch. When branch is empty (caused by a
+// trailing "|"), the message explicitly names the empty branch rather than
+// printing the confusing bare `(branch: "")`.
+func alternationWarning(field, reason, pattern, branch string) string {
+	if branch == "" {
+		return fmt.Sprintf(
+			"rule %q: %s %q has a trailing | that creates an empty unanchored branch; the empty branch matches any path as a substring, which may allow traversal bypass",
+			reason, field, pattern,
+		)
+	}
+	return fmt.Sprintf(
+		"rule %q: %s %q has an alternation branch without a ^ anchor (branch: %q); unanchored branches are matched as substrings, which may allow traversal bypass",
+		reason, field, pattern, branch,
+	)
+}
+
 // Warnings returns a list of non-fatal configuration warnings for cfg.
 // Currently warns about file_path_regex and file_path_exclude_regex patterns
 // that are not anchored at the start, which allows substring matching and can
@@ -248,10 +265,7 @@ func Warnings(cfg *Config) []Warning {
 		} else if r.FilePathRegex != "" {
 			if branch, ok := firstUnanchoredBranch(r.FilePathRegex); ok {
 				warnings = append(warnings, Warning{
-					Message: fmt.Sprintf(
-						"rule %q: file_path_regex %q has an alternation branch without a ^ anchor (branch: %q); unanchored branches are matched as substrings, which may allow traversal bypass",
-						r.Reason, r.FilePathRegex, branch,
-					),
+					Message: alternationWarning("file_path_regex", r.Reason, r.FilePathRegex, branch),
 				})
 			}
 		}
@@ -265,10 +279,7 @@ func Warnings(cfg *Config) []Warning {
 		} else if r.FilePathExcludeRegex != "" {
 			if branch, ok := firstUnanchoredBranch(r.FilePathExcludeRegex); ok {
 				warnings = append(warnings, Warning{
-					Message: fmt.Sprintf(
-						"rule %q: file_path_exclude_regex %q has an alternation branch without a ^ anchor (branch: %q); unanchored branches are matched as substrings, which may allow traversal bypass",
-						r.Reason, r.FilePathExcludeRegex, branch,
-					),
+					Message: alternationWarning("file_path_exclude_regex", r.Reason, r.FilePathExcludeRegex, branch),
 				})
 			}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -310,6 +310,29 @@ reason = "char class with pipe"
 			wantWarnings: 1,
 		},
 		{
+			name: "trailing pipe in file_path_regex — warning names empty branch explicitly",
+			toml: `
+[[deny]]
+tool = "Write"
+file_path_regex = "^/etc/|"
+reason = "system files"
+`,
+			wantWarnings:        1,
+			wantMessageContains: "trailing |",
+		},
+		{
+			name: "trailing pipe in file_path_exclude_regex — warning names empty branch explicitly",
+			toml: `
+[[allow]]
+tool = "Read"
+file_path_regex = "^/home/"
+file_path_exclude_regex = "^/home/root|"
+reason = "home but not root"
+`,
+			wantWarnings:        1,
+			wantMessageContains: "trailing |",
+		},
+		{
 			name: "anchored alternation in file_path_exclude_regex — no warning",
 			toml: `
 [[allow]]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -318,7 +318,7 @@ file_path_regex = "^/etc/|"
 reason = "system files"
 `,
 			wantWarnings:        1,
-			wantMessageContains: "trailing |",
+			wantMessageContains: "empty alternation branch",
 		},
 		{
 			name: "trailing pipe in file_path_exclude_regex — warning names empty branch explicitly",
@@ -330,7 +330,18 @@ file_path_exclude_regex = "^/home/root|"
 reason = "home but not root"
 `,
 			wantWarnings:        1,
-			wantMessageContains: "trailing |",
+			wantMessageContains: "empty alternation branch",
+		},
+		{
+			name: "middle double pipe — warning names empty branch explicitly",
+			toml: `
+[[deny]]
+tool = "Write"
+file_path_regex = "^/etc/||^/usr/"
+reason = "system files"
+`,
+			wantWarnings:        1,
+			wantMessageContains: "empty alternation branch",
 		},
 		{
 			name: "anchored alternation in file_path_exclude_regex — no warning",


### PR DESCRIPTION
## Summary
- Adds `alternationWarning()` helper to deduplicate message formatting for `file_path_regex` and `file_path_exclude_regex` alternation cases
- When the unanchored branch is empty (from a trailing `|`), the message now says `"has a trailing | that creates an empty unanchored branch"` instead of the confusing `(branch: "")`
- Adds 2 new test cases covering trailing `|` in both regex fields

Fixes #30

## Test plan
- [x] `go vet ./... && go test ./...` passes
- [x] New test cases `trailing pipe in file_path_regex` and `trailing pipe in file_path_exclude_regex` pass
- [x] Existing `alternation with unanchored branch` test still checks for `branch: "unanchored"` — unaffected