### PR TITLE
feat(shellsplit): skip [ / test / [[ as emitted commands

### DIFF
--- a/internal/shellsplit/shellsplit.go
+++ b/internal/shellsplit/shellsplit.go
@@ -87,6 +87,13 @@ func splitWithDepth(cmd string, depth int) []string {
 				break
 			}
 
+			// Skip test/condition commands: [ ... ], test ..., [[ ... ]] (CallExpr form).
+			// These are condition evaluators, not program executors. The walk
+			// continues to descend so any $(dangerous_cmd) inside is still extracted.
+			if isTestCommand(call) {
+				break
+			}
+
 			// Detect bash/sh invocations and handle specially.
 			info := classifyShellCall(call)
 			switch info.action {
@@ -115,7 +122,7 @@ func splitWithDepth(cmd string, depth int) []string {
 			if s != "" {
 				commands = append(commands, s)
 			}
-		case *syntax.DeclClause, *syntax.TestClause:
+		case *syntax.DeclClause:
 			var buf bytes.Buffer
 			printer.Print(&buf, stmt)
 			s := strings.TrimSpace(buf.String())
@@ -152,6 +159,18 @@ func printCommand(printer *syntax.Printer, stmt *syntax.Stmt, call *syntax.CallE
 	var buf bytes.Buffer
 	printer.Print(&buf, stmt)
 	return strings.TrimSpace(buf.String())
+}
+
+// isTestCommand reports whether a CallExpr is a shell test/condition command
+// ([ ... ] or test ...). These are condition evaluators, not program executors,
+// so they should not be emitted as sub-commands. The walk still descends into
+// them to extract any command substitutions (e.g. [ $(dangerous) ]).
+func isTestCommand(call *syntax.CallExpr) bool {
+	if len(call.Args) == 0 {
+		return false
+	}
+	name, ok := wordStaticValue(call.Args[0])
+	return ok && (name == "[" || name == "test")
 }
 
 // classifyShellCall determines if a CallExpr is a bash/sh invocation

--- a/internal/shellsplit/shellsplit_test.go
+++ b/internal/shellsplit/shellsplit_test.go
@@ -153,6 +153,11 @@ func TestSplit(t *testing.T) {
 			want:  []string{"dangerous_cmd"},
 		},
 		{
+			name:  "dangerous cmd subst in test is extracted",
+			input: "test $(dangerous_cmd)",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
 			name:  "compound script with if [ ] emits only inner commands",
 			input: "if [ -z \"$CADENCE_ROOT\" ] && [ -f \".claude-plugin/plugin.json\" ]; then CADENCE_ROOT=\"$(pwd)\"; fi",
 			want:  []string{"pwd"},

--- a/internal/shellsplit/shellsplit_test.go
+++ b/internal/shellsplit/shellsplit_test.go
@@ -119,7 +119,7 @@ func TestSplit(t *testing.T) {
 		{
 			name:  "if then else fi",
 			input: "if [ -f foo ]; then echo yes; else echo no; fi",
-			want:  []string{"[ -f foo ]", "echo yes", "echo no"},
+			want:  []string{"echo yes", "echo no"},
 		},
 		{
 			name:  "for loop",
@@ -139,7 +139,28 @@ func TestSplit(t *testing.T) {
 		{
 			name:  "test clause",
 			input: "if [[ -f foo ]]; then echo yes; fi",
-			want:  []string{"[[ -f foo ]]", "echo yes"},
+			want:  []string{"echo yes"},
+		},
+		// Test commands: dangerous command substitutions inside must still be extracted
+		{
+			name:  "dangerous cmd subst in [ ] is extracted",
+			input: "[ $(dangerous_cmd) ]",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
+			name:  "dangerous cmd subst in [[ ]] is extracted",
+			input: "[[ $(dangerous_cmd) == foo ]]",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
+			name:  "compound script with if [ ] emits only inner commands",
+			input: "if [ -z \"$CADENCE_ROOT\" ] && [ -f \".claude-plugin/plugin.json\" ]; then CADENCE_ROOT=\"$(pwd)\"; fi",
+			want:  []string{"pwd"},
+		},
+		{
+			name:  "test command standalone skipped",
+			input: "test -z \"$VAR\"",
+			want:  []string{"test -z \"$VAR\""}, // fallback: single element returned as-is
 		},
 		// Variable assignments — should not emit the assignment wrapper
 		{


### PR DESCRIPTION
## Summary

- Adds `isTestCommand` helper that returns true for `[` and `test` command names
- `CallExpr` case skips emission when `isTestCommand` returns true, so compound scripts with `if [ ... ]` conditions no longer produce phantom sub-commands requiring allow rules
- Removes `*syntax.TestClause` from the explicit emit case so `[[ ... ]]` is also skipped
- Walk continues descending into skipped nodes — `$(dangerous_cmd)` inside test expressions is still extracted and evaluated

Fixes the real-world issue where scripts like:
```bash
if [ -z "$CADENCE_ROOT" ] && [ -f ".claude-plugin/plugin.json" ]; then
  CADENCE_ROOT="$(pwd)"
fi
```
fell through to passthrough because `[ -z "$CADENCE_ROOT" ]` matched no allow rule.

Closes #37

## Test plan

- [x] Updated `"if then else fi"` test: `"[ -f foo ]"` removed from `want`
- [x] Updated `"test clause"` test: `"[[ -f foo ]]"` removed from `want`
- [x] New test: `[ $(dangerous_cmd) ]` — verifies `dangerous_cmd` IS still extracted
- [x] New test: `[[ $(dangerous_cmd) == foo ]]` — verifies `dangerous_cmd` IS still extracted
- [x] New test: compound `if [ -z ... ] && [ -f ... ]; then CADENCE_ROOT="$(pwd)"; fi` — verifies only `pwd` emitted
- [x] `go test ./internal/shellsplit/` passes
- [x] `go vet ./... && go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)