### PR TITLE
fix(shellsplit): skip DeclClause as emitted command (#38)

### DIFF
--- a/examples/hooks-config.toml
+++ b/examples/hooks-config.toml
@@ -44,7 +44,7 @@ reason = "Blocked writing secrets (.env/.pem/.key)"
 
 [[allow]]
 tool = "Bash"
-command_regex = "^(bash|cargo|cat|cp|curl|diff|du|echo|env|export|file|find|grep|head|kill|killall|ls|lsof|make|mkdir|mv|nc|npm|npx|open|pgrep|pkill|pwd|pytest|sort|tail|tee|test|touch|tree|unzip|wc|which|yq)( |$)"
+command_regex = "^(bash|cargo|cat|cp|curl|diff|du|echo|env|file|find|grep|head|kill|killall|ls|lsof|make|mkdir|mv|nc|npm|npx|open|pgrep|pkill|pwd|pytest|sort|tail|tee|test|touch|tree|unzip|wc|which|yq)( |$)"
 reason = "Simple command"
 
 [[allow]]

--- a/internal/shellsplit/shellsplit.go
+++ b/internal/shellsplit/shellsplit.go
@@ -73,7 +73,7 @@ func splitWithDepth(cmd string, depth int) []string {
 			return true
 		}
 
-		// Collect leaf commands (simple commands, declarations, test expressions).
+		// Collect leaf commands (simple commands, test expressions).
 		// Skip compound nodes (BinaryCmd, IfClause, etc.) — Walk descends
 		// into them to find the leaf commands inside.
 		switch call := stmt.Cmd.(type) {
@@ -119,13 +119,6 @@ func splitWithDepth(cmd string, depth int) []string {
 
 			// Normal command: emit it.
 			s := printCommand(printer, stmt, call)
-			if s != "" {
-				commands = append(commands, s)
-			}
-		case *syntax.DeclClause:
-			var buf bytes.Buffer
-			printer.Print(&buf, stmt)
-			s := strings.TrimSpace(buf.String())
 			if s != "" {
 				commands = append(commands, s)
 			}

--- a/internal/shellsplit/shellsplit_test.go
+++ b/internal/shellsplit/shellsplit_test.go
@@ -255,6 +255,16 @@ func TestSplit(t *testing.T) {
 			want:  []string{"dangerous_cmd", "echo done"},
 		},
 		{
+			name:  "typeset with dangerous command extracts inner",
+			input: "typeset VAR=$(dangerous_cmd)",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
+			name:  "readonly with dangerous command extracts inner",
+			input: "readonly VAR=$(dangerous_cmd)",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
 			name:  "nested substitution in assignment",
 			input: "X=$(echo $(rm -rf /)) && ls",
 			want:  []string{"echo $(rm -rf /)", "rm -rf /", "ls"},

--- a/internal/shellsplit/shellsplit_test.go
+++ b/internal/shellsplit/shellsplit_test.go
@@ -186,7 +186,7 @@ func TestSplit(t *testing.T) {
 		{
 			name:  "export with command substitution",
 			input: "export VAR=$(whoami) && echo done",
-			want:  []string{"export VAR=$(whoami)", "whoami", "echo done"},
+			want:  []string{"whoami", "echo done"},
 		},
 		{
 			name:  "multiple assignments with command substitution",
@@ -235,9 +235,24 @@ func TestSplit(t *testing.T) {
 			want:  []string{"magick in.png out.png", "file out.png", "magick identify out.png"},
 		},
 		{
-			name:  "declare with command substitution emits both",
+			name:  "declare with command substitution emits inner only",
 			input: "declare -x FOO=$(cmd)",
-			want:  []string{"declare -x FOO=$(cmd)", "cmd"},
+			want:  []string{"cmd"},
+		},
+		{
+			name:  "declare with static value emits nothing (fallback)",
+			input: "declare -x FOO=static_value",
+			want:  []string{"declare -x FOO=static_value"}, // fallback: single element returned as-is
+		},
+		{
+			name:  "local with dangerous command extracts inner",
+			input: "local VAR=$(dangerous_cmd)",
+			want:  []string{"dangerous_cmd"},
+		},
+		{
+			name:  "export with dangerous command and compound",
+			input: "export VAR=$(dangerous_cmd) && echo done",
+			want:  []string{"dangerous_cmd", "echo done"},
 		},
 		{
 			name:  "nested substitution in assignment",


### PR DESCRIPTION
## Summary

- Removes `*syntax.DeclClause` from the explicit emit case in `shellsplit.go` so `declare`, `local`, `typeset`, `readonly`, and `export` are no longer emitted as standalone commands
- The AST Walk continues descending into DeclClause nodes, extracting any `$(cmd)` substitutions inside — security is preserved
- Removes `export` from the long command allow list in `hooks-config.toml` (it was added as a workaround for this exact bug)

## Test plan

- [x] Updated `"declare with command substitution emits inner only"` — `declare -x FOO=$(cmd)` now yields only `["cmd"]`
- [x] Updated `"export with command substitution"` — `export VAR=$(whoami) && echo done` now yields `["whoami", "echo done"]`
- [x] New: `"declare with static value emits nothing (fallback)"` — `declare -x FOO=static_value` falls back to `["declare -x FOO=static_value"]`
- [x] New: `"local with dangerous command extracts inner"` — `local VAR=$(dangerous_cmd)` yields `["dangerous_cmd"]`
- [x] New: `"export with dangerous command and compound"` — `export VAR=$(dangerous_cmd) && echo done` yields `["dangerous_cmd", "echo done"]`
- [x] `go test ./...` passes (63 shellsplit tests, all packages green)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)